### PR TITLE
Fix VK API error #100: Primary attachments grid mode should not have audio

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/konard/vk-bot/issues/121
-Your prepared branch: issue-121-f13d4250
-Your prepared working directory: /tmp/gh-issue-solver-1758562458143
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/konard/vk-bot/issues/121
+Your prepared branch: issue-121-f13d4250
+Your prepared working directory: /tmp/gh-issue-solver-1758562458143
+
+Proceed.

--- a/triggers/send-invitation-posts-for-friends.js
+++ b/triggers/send-invitation-posts-for-friends.js
@@ -138,10 +138,15 @@ async function sendInvitationPosts(context) {
 
         const message = restrictedCommunities.includes(communityId) ? restrictedPostMessage : postMessage;
 
-        const avatarAttachment = await uploadAvatarPicture(context, communityId, avatarImagePath);
-        let attachments = [avatarAttachment];
-        if (!restrictedCommunities.includes(communityId)) {
-          attachments.push(getRandomElement(audioAttachments));
+        let attachments;
+        if (restrictedCommunities.includes(communityId)) {
+          // For restricted communities, use only photo attachment
+          const avatarAttachment = await uploadAvatarPicture(context, communityId, avatarImagePath);
+          attachments = [avatarAttachment];
+        } else {
+          // For non-restricted communities, use only audio attachment to avoid VK API grid mode error
+          // VK API does not allow mixing photo and audio attachments in grid mode
+          attachments = [getRandomElement(audioAttachments)];
         }
 
         // await context.vk.api.wall.post({ owner_id: ownerId, message, attachments: attachments.join(',') });


### PR DESCRIPTION
## Summary
- Fixes VK API error #100: "Primary attachments grid mode should not have audio attachments"
- Modifies wall post attachment logic to prevent mixing photo and audio attachments
- Restricted communities use only photo attachments, non-restricted use only audio attachments

## Root Cause
The VK API rejects wall posts that mix photo and audio attachments in grid mode. The previous implementation was adding both avatar photos and audio files to the same post, causing the error.

## Solution
Split attachment logic:
- **Restricted communities**: Use only photo attachments (avatar images)
- **Non-restricted communities**: Use only audio attachments to avoid API rejection

## Test Plan
- [x] Verify module loads without syntax errors
- [x] Test attachment selection logic for both community types
- [x] Confirm no mixing of photo and audio attachments
- [x] Push changes and verify commit

🤖 Generated with [Claude Code](https://claude.ai/code)