### PR TITLE
Add feature to like friends' avatars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/konard/vk-bot/issues/101
+Your prepared branch: issue-101-667e29cd
+Your prepared working directory: /tmp/gh-issue-solver-1758563972868
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/konard/vk-bot/issues/101
-Your prepared branch: issue-101-667e29cd
-Your prepared working directory: /tmp/gh-issue-solver-1758563972868
-
-Proceed.

--- a/__tests__/triggers/like-friends-avatars.js
+++ b/__tests__/triggers/like-friends-avatars.js
@@ -1,0 +1,31 @@
+const { trigger } = require('../../triggers/like-friends-avatars');
+
+describe('LikeFriendsAvatars Trigger', () => {
+  test('should have correct trigger structure', () => {
+    expect(trigger).toBeDefined();
+    expect(trigger.name).toBe('LikeFriendsAvatars');
+    expect(typeof trigger.action).toBe('function');
+  });
+
+  test('should handle empty context gracefully', async () => {
+    const mockContext = {
+      vk: {
+        api: {
+          friends: {
+            get: jest.fn().mockResolvedValue({ items: [] })
+          }
+        }
+      },
+      options: { maxLikes: 1, minDelaySeconds: 1 }
+    };
+
+    // Mock the getAllFriends function to return empty array
+    jest.doMock('../../friends-cache', () => ({
+      getAllFriends: jest.fn().mockResolvedValue([])
+    }));
+
+    const result = await trigger.action(mockContext);
+    // Should not throw error with empty friends list
+    expect(result).toBeUndefined();
+  });
+});

--- a/experiments/like-avatar-test.js
+++ b/experiments/like-avatar-test.js
@@ -1,0 +1,56 @@
+const { getToken } = require('../utils');
+const { VK } = require('vk-io');
+
+// Test script to understand how to like user profile photos (avatars)
+async function testLikingAvatar() {
+  const token = getToken();
+  const vk = new VK({ token });
+
+  try {
+    // Get info about the current user to test with
+    const user = await vk.api.users.get({ fields: ['photo_id'] });
+    console.log('Current user info:', user);
+
+    // For testing, let's try to get a friend's info first
+    const friends = await vk.api.friends.get({ count: 1, fields: ['photo_id'] });
+    if (friends.items.length > 0) {
+      const friend = friends.items[0];
+      console.log('Friend info:', friend);
+
+      // Try to like the friend's profile photo
+      // The VK API likes.add method requires:
+      // - type: 'photo' for photos
+      // - owner_id: user ID who owns the photo
+      // - item_id: photo ID
+
+      if (friend.photo_id) {
+        console.log(`Attempting to like ${friend.first_name} ${friend.last_name}'s avatar (photo_id: ${friend.photo_id})`);
+
+        try {
+          const result = await vk.api.likes.add({
+            type: 'photo',
+            owner_id: friend.id,
+            item_id: friend.photo_id
+          });
+          console.log('Like result:', result);
+        } catch (error) {
+          console.error('Error liking photo:', error);
+        }
+      } else {
+        console.log('Friend does not have a profile photo or photo_id is not available');
+      }
+    } else {
+      console.log('No friends found for testing');
+    }
+
+  } catch (error) {
+    console.error('Error in test:', error);
+  }
+}
+
+// Only run if called directly
+if (require.main === module) {
+  testLikingAvatar();
+}
+
+module.exports = { testLikingAvatar };

--- a/experiments/test-like-trigger.js
+++ b/experiments/test-like-trigger.js
@@ -1,0 +1,31 @@
+const { getToken } = require('../utils');
+const { VK } = require('vk-io');
+const { likeFriendsAvatars } = require('../triggers/like-friends-avatars');
+
+// Test the like friends avatars trigger
+async function testLikeTrigger() {
+  const token = getToken();
+  const vk = new VK({ token });
+
+  console.log('Testing the like friends avatars trigger...');
+
+  try {
+    // Run the trigger with limited options for testing
+    await likeFriendsAvatars({
+      vk,
+      options: {
+        maxLikes: 3, // Limit to 3 for testing
+        minDelaySeconds: 5 // Shorter delay for testing
+      }
+    });
+
+    console.log('Test completed successfully!');
+  } catch (error) {
+    console.error('Test failed:', error);
+  }
+}
+
+// Only run if called directly
+if (require.main === module) {
+  testLikeTrigger();
+}

--- a/index.js
+++ b/index.js
@@ -130,3 +130,10 @@ const sendBirthDayCongratulationsIntervalAction = async () => {
 }
 const sendBirthDayCongratulationsInterval = setInterval(sendBirthDayCongratulationsIntervalAction, (23 * 60 * minute) / ms);
 // sendBirthDayCongratulationsIntervalAction();
+
+const { trigger: likeFriendsAvatarsTrigger } = require('./triggers/like-friends-avatars');
+const likeFriendsAvatarsIntervalAction = async () => {
+  await executeTrigger(likeFriendsAvatarsTrigger, { vk, options: { maxLikes: 30, minDelaySeconds: 45 } });
+};
+const likeFriendsAvatarsInterval = setInterval(likeFriendsAvatarsIntervalAction, (6 * 60 * minute) / ms);
+// likeFriendsAvatarsIntervalAction(); // Uncomment to run immediately on start

--- a/triggers/like-friends-avatars.js
+++ b/triggers/like-friends-avatars.js
@@ -1,0 +1,97 @@
+const { getAllFriends } = require('../friends-cache');
+const { sleep, second, minute, ms } = require('../utils');
+
+async function likeFriendsAvatars({ vk, options = {} }) {
+  const { maxLikes = 50, minDelaySeconds = 30 } = options;
+
+  try {
+    console.log('Starting to like friends avatars...');
+
+    // Get all friends with photo_id field
+    const allFriends = await getAllFriends({
+      context: { vk },
+      fields: ['photo_id', 'online', 'last_seen', 'deactivated']
+    });
+
+    if (!allFriends || allFriends.length === 0) {
+      console.log('No friends found to like avatars.');
+      return;
+    }
+
+    console.log(`Found ${allFriends.length} friends. Processing avatars...`);
+
+    let likesCount = 0;
+
+    // Filter friends who have profile photos and are not deactivated
+    const friendsWithAvatars = allFriends.filter(friend =>
+      friend.photo_id &&
+      !friend.deactivated &&
+      friend.id // Ensure friend has valid ID
+    );
+
+    console.log(`${friendsWithAvatars.length} friends have avatars to like.`);
+
+    // Shuffle the friends array to avoid predictable patterns
+    const shuffledFriends = friendsWithAvatars.sort(() => 0.5 - Math.random());
+
+    for (const friend of shuffledFriends) {
+      if (likesCount >= maxLikes) {
+        console.log(`Reached maximum likes limit (${maxLikes}). Stopping.`);
+        break;
+      }
+
+      try {
+        console.log(`Attempting to like ${friend.first_name || 'Unknown'} ${friend.last_name || 'Friend'}'s avatar (ID: ${friend.id}, Photo ID: ${friend.photo_id})`);
+
+        const result = await vk.api.likes.add({
+          type: 'photo',
+          owner_id: friend.id,
+          item_id: friend.photo_id
+        });
+
+        if (result.likes) {
+          likesCount++;
+          console.log(`✓ Liked ${friend.first_name || 'Unknown'}'s avatar. Total likes: ${result.likes}`);
+        } else {
+          console.log(`✓ Processed ${friend.first_name || 'Unknown'}'s avatar.`);
+        }
+
+        // Wait between likes to avoid rate limiting
+        const delayMs = (minDelaySeconds * second) / ms;
+        await sleep(delayMs);
+
+      } catch (error) {
+        if (error.code === 15) {
+          console.log(`Cannot like ${friend.first_name || 'Unknown'}'s avatar - access denied or privacy settings.`);
+        } else if (error.code === 7) {
+          console.log(`Cannot like ${friend.first_name || 'Unknown'}'s avatar - already liked or photo doesn't exist.`);
+        } else if (error.code === 29) {
+          console.log('Rate limit reached. Waiting longer before next attempt...');
+          await sleep((2 * minute) / ms);
+        } else {
+          console.error(`Error liking ${friend.first_name || 'Unknown'}'s avatar:`, error);
+        }
+
+        // Wait a bit even after errors
+        await sleep((10 * second) / ms);
+      }
+    }
+
+    console.log(`Finished liking friends avatars. Total likes given: ${likesCount}`);
+
+  } catch (error) {
+    console.error('Error in likeFriendsAvatars:', error);
+  }
+}
+
+const trigger = {
+  name: "LikeFriendsAvatars",
+  action: async (context) => {
+    return await likeFriendsAvatars(context);
+  }
+};
+
+module.exports = {
+  trigger,
+  likeFriendsAvatars
+};


### PR DESCRIPTION
'## Summary
- Implemented automatic liking of friends'\'' profile photos (avatars)
- Added configurable trigger that runs every 6 hours
- Includes rate limiting and error handling to respect VK API limits
- Added unit tests and experiment scripts for testing

## Implementation Details
- **New trigger**:  - Main implementation with VK API  calls
- **Integration**: Added to  with 6-hour interval and configurable options
- **Safety features**: Rate limiting (45 seconds between likes), maximum likes per run (30), error handling for various VK API error codes
- **Testing**: Unit test coverage and experiment scripts for manual testing

## Configuration
The trigger runs automatically every 6 hours with these default settings:
- Maximum 30 likes per execution
- 45-second delay between individual likes
- Only processes friends with valid profile photos
- Skips deactivated accounts

## Test plan
- [x] Syntax validation passes
- [x] Unit tests created for trigger structure
- [x] Experiment scripts created for manual testing
- [x] Integration added to main bot loop
- [x] Error handling implemented for common VK API scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)


Fixes #101'