### PR TITLE
Auto mute chats where user account was added

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/konard/vk-bot/issues/96
-Your prepared branch: issue-96-1f5db091
-Your prepared working directory: /tmp/gh-issue-solver-1758564329027
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/konard/vk-bot/issues/96
+Your prepared branch: issue-96-1f5db091
+Your prepared working directory: /tmp/gh-issue-solver-1758564329027
+
+Proceed.

--- a/__tests__/triggers/auto-mute-on-invite.js
+++ b/__tests__/triggers/auto-mute-on-invite.js
@@ -1,0 +1,115 @@
+const { trigger: autoMuteOnInviteTrigger } = require('../../triggers/auto-mute-on-invite');
+
+describe('AutoMuteOnInvite Trigger', () => {
+  let mockVk;
+  let mockRequest;
+
+  beforeEach(() => {
+    mockVk = {
+      api: {
+        users: {
+          get: jest.fn()
+        },
+        messages: {
+          setConversationMember: jest.fn()
+        },
+        account: {
+          setPushSettings: jest.fn(),
+          setSilenceMode: jest.fn()
+        }
+      }
+    };
+
+    mockRequest = {
+      peerId: 2000000001,
+      isEvent: false,
+      eventType: null,
+      eventMemberId: null
+    };
+  });
+
+  test('should ignore non-event messages', async () => {
+    mockRequest.isEvent = false;
+
+    await autoMuteOnInviteTrigger.action({ vk: mockVk, request: mockRequest });
+
+    expect(mockVk.api.users.get).not.toHaveBeenCalled();
+  });
+
+  test('should ignore non-chat_invite_user events', async () => {
+    mockRequest.isEvent = true;
+    mockRequest.eventType = 'chat_photo_update';
+
+    await autoMuteOnInviteTrigger.action({ vk: mockVk, request: mockRequest });
+
+    expect(mockVk.api.users.get).not.toHaveBeenCalled();
+  });
+
+  test('should ignore when other users are invited', async () => {
+    mockRequest.isEvent = true;
+    mockRequest.eventType = 'chat_invite_user';
+    mockRequest.eventMemberId = 123456;
+
+    mockVk.api.users.get.mockResolvedValue([{ id: 789012 }]);
+
+    await autoMuteOnInviteTrigger.action({ vk: mockVk, request: mockRequest });
+
+    expect(mockVk.api.messages.setConversationMember).not.toHaveBeenCalled();
+  });
+
+  test('should mute conversation when bot is invited using setConversationMember', async () => {
+    const botUserId = 789012;
+    mockRequest.isEvent = true;
+    mockRequest.eventType = 'chat_invite_user';
+    mockRequest.eventMemberId = botUserId;
+
+    mockVk.api.users.get.mockResolvedValue([{ id: botUserId }]);
+    mockVk.api.messages.setConversationMember.mockResolvedValue({});
+
+    await autoMuteOnInviteTrigger.action({ vk: mockVk, request: mockRequest });
+
+    expect(mockVk.api.messages.setConversationMember).toHaveBeenCalledWith({
+      peer_id: mockRequest.peerId,
+      member_id: botUserId,
+      push_settings: 'disabled'
+    });
+  });
+
+  test('should fallback to setPushSettings when setConversationMember fails', async () => {
+    const botUserId = 789012;
+    mockRequest.isEvent = true;
+    mockRequest.eventType = 'chat_invite_user';
+    mockRequest.eventMemberId = botUserId;
+
+    mockVk.api.users.get.mockResolvedValue([{ id: botUserId }]);
+    mockVk.api.messages.setConversationMember.mockRejectedValue(new Error('Method not available'));
+    mockVk.api.account.setPushSettings.mockResolvedValue({});
+
+    await autoMuteOnInviteTrigger.action({ vk: mockVk, request: mockRequest });
+
+    expect(mockVk.api.account.setPushSettings).toHaveBeenCalledWith({
+      peer_id: mockRequest.peerId,
+      sound: 0,
+      disabled_until: -1
+    });
+  });
+
+  test('should fallback to setSilenceMode when other methods fail', async () => {
+    const botUserId = 789012;
+    mockRequest.isEvent = true;
+    mockRequest.eventType = 'chat_invite_user';
+    mockRequest.eventMemberId = botUserId;
+
+    mockVk.api.users.get.mockResolvedValue([{ id: botUserId }]);
+    mockVk.api.messages.setConversationMember.mockRejectedValue(new Error('Method not available'));
+    mockVk.api.account.setPushSettings.mockRejectedValue(new Error('Method not available'));
+    mockVk.api.account.setSilenceMode.mockResolvedValue({});
+
+    await autoMuteOnInviteTrigger.action({ vk: mockVk, request: mockRequest });
+
+    expect(mockVk.api.account.setSilenceMode).toHaveBeenCalledWith({
+      peer_id: mockRequest.peerId,
+      time: -1
+    });
+  });
+});

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const { handleOutgoingMessage } = require('./outgoing-messages');
 const peers = {}; // TODO: keep state about what triggers then last triggered for each peer
 
 const triggers = [
+  require('./triggers/auto-mute-on-invite').trigger,
   // require('./triggers/acquaintance').trigger,
   // require('./triggers/attachments').trigger,
   // require('./triggers/goal').trigger,

--- a/triggers/auto-mute-on-invite.js
+++ b/triggers/auto-mute-on-invite.js
@@ -1,0 +1,74 @@
+const { executeTrigger, getToken } = require('../utils');
+
+async function autoMuteOnInvite({ vk, request }) {
+  try {
+    // Check if this is a chat invite event
+    if (!request.isEvent || request.eventType !== 'chat_invite_user') {
+      return;
+    }
+
+    const peerId = request.peerId;
+    const invitedMemberId = request.eventMemberId;
+
+    // Get bot user ID to check if bot was invited
+    const botInfo = await vk.api.users.get();
+    const botUserId = botInfo[0].id;
+
+    // Check if the bot was the one invited
+    if (invitedMemberId !== botUserId) {
+      return;
+    }
+
+    console.log(`Bot was invited to chat ${peerId}, attempting to mute conversation...`);
+
+    // Try to mute the conversation using available VK API methods
+    try {
+      // Method 1: Try using messages.setConversationMember if available
+      await vk.api.messages.setConversationMember({
+        peer_id: peerId,
+        member_id: botUserId,
+        push_settings: 'disabled'
+      });
+      console.log(`Successfully muted conversation ${peerId} using setConversationMember`);
+    } catch (error) {
+      console.log('setConversationMember method failed, trying alternative approach:', error.message);
+
+      try {
+        // Method 2: Try using account.setPushSettings for the conversation
+        await vk.api.account.setPushSettings({
+          peer_id: peerId,
+          sound: 0,
+          disabled_until: -1 // Disable indefinitely
+        });
+        console.log(`Successfully muted conversation ${peerId} using setPushSettings`);
+      } catch (error2) {
+        console.log('setPushSettings method failed, trying setSilenceMode:', error2.message);
+
+        try {
+          // Method 3: Try using account.setSilenceMode for the specific peer
+          await vk.api.account.setSilenceMode({
+            peer_id: peerId,
+            time: -1 // Mute indefinitely
+          });
+          console.log(`Successfully muted conversation ${peerId} using setSilenceMode`);
+        } catch (error3) {
+          console.error(`Failed to mute conversation ${peerId} with all methods:`, error3.message);
+        }
+      }
+    }
+
+  } catch (error) {
+    console.error('Error in autoMuteOnInvite trigger:', error);
+  }
+}
+
+const trigger = {
+  name: "AutoMuteOnInvite",
+  action: async (context) => {
+    return await autoMuteOnInvite(context);
+  }
+};
+
+module.exports = {
+  trigger
+};


### PR DESCRIPTION
## Summary

This PR implements automatic muting of chat conversations when the bot's user account is invited to a chat.

### 📋 Issue Reference
Fixes #96

### 🚀 Implementation Details

- **New Trigger**: `auto-mute-on-invite.js` that listens for `chat_invite_user` events
- **Event Detection**: Uses VK-IO's `isEvent` and `eventType` properties to detect when the bot is invited to chats
- **Fallback Strategy**: Implements multiple muting methods with graceful fallbacks:
  1. `messages.setConversationMember` with `push_settings: 'disabled'`
  2. `account.setPushSettings` with indefinite disable
  3. `account.setSilenceMode` with indefinite mute
- **Bot Identification**: Automatically fetches bot's user ID and only mutes when the bot itself is invited

### 🛠️ Files Added/Modified

- `triggers/auto-mute-on-invite.js` - Main trigger implementation
- `index.js` - Added trigger to the triggers array
- `__tests__/triggers/auto-mute-on-invite.js` - Comprehensive test suite

### ✅ Test Coverage

The implementation includes 6 comprehensive tests covering:
- ✓ Ignoring non-event messages
- ✓ Ignoring non-chat_invite_user events 
- ✓ Ignoring when other users are invited
- ✓ Successfully muting using primary method
- ✓ Fallback to secondary muting method
- ✓ Fallback to tertiary muting method

All tests pass successfully.

### 🔧 How It Works

1. The trigger listens to all incoming messages through the VK-IO message handler
2. When a `chat_invite_user` event is detected, it checks if the invited member is the bot
3. If the bot was invited, it attempts to mute the conversation using available VK API methods
4. The implementation uses a robust fallback strategy to ensure muting works across different VK API versions

### 🎯 Benefits

- **Automatic**: No manual intervention required
- **Robust**: Multiple fallback methods ensure reliability
- **Tested**: Comprehensive test suite ensures correctness
- **Minimal Impact**: Only processes relevant events, no performance overhead

🤖 Generated with [Claude Code](https://claude.ai/code)