### PR TITLE
Add Venus Project/Jacque Fresco initiation topic trigger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/konard/vk-bot/issues/92
+Your prepared branch: issue-92-27193ea2
+Your prepared working directory: /tmp/gh-issue-solver-1758565006180
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/konard/vk-bot/issues/92
-Your prepared branch: issue-92-27193ea2
-Your prepared working directory: /tmp/gh-issue-solver-1758565006180
-
-Proceed.

--- a/__tests__/triggers/venus-project-initiation.js
+++ b/__tests__/triggers/venus-project-initiation.js
@@ -1,0 +1,131 @@
+const { trigger: venusProjectTrigger, questions } = require('../../triggers/venus-project-initiation');
+const { enqueueMessage } = require('../../outgoing-messages');
+
+jest.mock('../../outgoing-messages');
+
+const triggerDescription = 'venus project initiation trigger';
+
+describe('venus project initiation trigger', () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test.each([
+    'что делаешь?',
+    'чем занимаешься?',
+    'что нового?',
+    'расскажи о себе',
+    'о чём поговорим?',
+    'что интересного?',
+  ])(`"%s" matches ${triggerDescription} and gives expected response`, (incomingMessage) => {
+    const context = {
+      request: {
+        isFromUser: true,
+        isOutbox: false,
+        text: incomingMessage
+      },
+      state: {
+        history: [
+          { text: incomingMessage, out: 0 },
+          { text: 'привет!', out: 1 },
+          { text: 'привет', out: 0 }
+        ],
+        triggers: {}
+      }
+    };
+
+    expect(venusProjectTrigger.condition(context)).toBe(true);
+    if (venusProjectTrigger.condition(context)) {
+      venusProjectTrigger.action(context);
+    }
+    expect(enqueueMessage).toHaveBeenCalled();
+    const callArg = enqueueMessage.mock.calls[0][0];
+    expect(callArg).toEqual(expect.objectContaining(context));
+    expect(questions).toContain(callArg.response.message);
+  });
+
+  test('outgoing message should not trigger', () => {
+    const context = {
+      request: {
+        isFromUser: true,
+        isOutbox: true,
+        text: 'что делаешь?'
+      },
+      state: {
+        history: [
+          { text: 'что делаешь?', out: 1 },
+          { text: 'привет!', out: 0 },
+          { text: 'привет', out: 1 }
+        ],
+        triggers: {}
+      }
+    };
+
+    expect(venusProjectTrigger.condition(context)).toBe(false);
+  });
+
+  test('long conversation should not trigger', () => {
+    const context = {
+      request: {
+        isFromUser: true,
+        isOutbox: false,
+        text: 'что делаешь?'
+      },
+      state: {
+        history: Array.from({ length: 10 }, (_, i) => ({
+          text: `message ${i}`,
+          out: i % 2
+        })),
+        triggers: {}
+      }
+    };
+
+    expect(venusProjectTrigger.condition(context)).toBe(false);
+  });
+
+  test('recently triggered should not trigger again', () => {
+    const context = {
+      request: {
+        isFromUser: true,
+        isOutbox: false,
+        text: 'что делаешь?'
+      },
+      state: {
+        history: [
+          { text: 'что делаешь?', out: 0 },
+          { text: 'привет!', out: 1 },
+          { text: 'привет', out: 0 }
+        ],
+        triggers: {
+          [venusProjectTrigger.name]: {
+            lastTriggered: new Date().toISOString()
+          }
+        }
+      }
+    };
+
+    expect(venusProjectTrigger.condition(context)).toBe(false);
+  });
+
+  test('should mark trigger as activated after action', () => {
+    const context = {
+      request: {
+        isFromUser: true,
+        isOutbox: false,
+        text: 'что делаешь?'
+      },
+      state: {
+        history: [
+          { text: 'что делаешь?', out: 0 },
+          { text: 'привет!', out: 1 },
+          { text: 'привет', out: 0 }
+        ],
+        triggers: {}
+      }
+    };
+
+    venusProjectTrigger.action(context);
+    expect(context.state.triggers[venusProjectTrigger.name].lastTriggered).toBeDefined();
+  });
+});

--- a/experiments/test-venus-project-trigger.js
+++ b/experiments/test-venus-project-trigger.js
@@ -1,0 +1,84 @@
+const { trigger } = require('../triggers/venus-project-initiation');
+
+// Mock context for testing
+function createMockContext(text, historyLength = 3, isFromUser = true, isOutbox = false) {
+  const history = [];
+  for (let i = 0; i < historyLength; i++) {
+    history.push({
+      id: i,
+      text: i === 0 ? text : `message ${i}`,
+      out: i % 2,
+      date: Date.now() - (i * 1000)
+    });
+  }
+
+  return {
+    request: {
+      isFromUser,
+      isOutbox,
+      text,
+      peerId: 12345
+    },
+    state: {
+      history,
+      triggers: {}
+    }
+  };
+}
+
+// Test cases
+console.log('Testing Venus Project Initiation Trigger...\n');
+
+// Test 1: Should trigger on conversation starter
+const context1 = createMockContext('что делаешь?', 3);
+console.log('Test 1 - "что делаешь?" (should trigger):', trigger.condition(context1));
+
+// Test 2: Should trigger on general question
+const context2 = createMockContext('чем занимаешься?', 4);
+console.log('Test 2 - "чем занимаешься?" (should trigger):', trigger.condition(context2));
+
+// Test 3: Should not trigger on outgoing message
+const context3 = createMockContext('что делаешь?', 3, true, true);
+console.log('Test 3 - Outgoing message (should not trigger):', trigger.condition(context3));
+
+// Test 4: Should not trigger on very long conversation
+const context4 = createMockContext('что делаешь?', 10);
+console.log('Test 4 - Long conversation (should not trigger):', trigger.condition(context4));
+
+// Test 5: Should not trigger if already triggered recently
+const context5 = createMockContext('что делаешь?', 3);
+context5.state.triggers[trigger.name] = {
+  lastTriggered: new Date().toISOString()
+};
+console.log('Test 5 - Recently triggered (should not trigger):', trigger.condition(context5));
+
+// Test 6: Should trigger after greeting exchange
+const context6 = createMockContext('расскажи о себе', 3);
+context6.state.history = [
+  { text: 'расскажи о себе', out: 0 },
+  { text: 'привет!', out: 1 },
+  { text: 'привет', out: 0 }
+];
+console.log('Test 6 - After greeting exchange (should trigger):', trigger.condition(context6));
+
+console.log('\nTesting trigger action...');
+// Test the action
+const testContext = createMockContext('что делаешь?', 3);
+testContext.response = {};
+
+// Mock enqueueMessage
+const originalEnqueue = require('../outgoing-messages').enqueueMessage;
+const messages = [];
+require('../outgoing-messages').enqueueMessage = (context) => {
+  messages.push(context.response.message);
+  console.log('Would send message:', context.response.message);
+};
+
+// Run the action
+trigger.action(testContext);
+console.log('Trigger marked as activated:', !!testContext.state.triggers[trigger.name]?.lastTriggered);
+
+// Restore original function
+require('../outgoing-messages').enqueueMessage = originalEnqueue;
+
+console.log('\nAll tests completed!');

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const triggers = [
   // require('./triggers/who-singular').trigger,
   // require('./triggers/have-we-talked-before').trigger,
   // require('./triggers/engage-with-acquaintance').trigger
+  require('./triggers/venus-project-initiation').trigger,
 ];
 
 const token = getToken();

--- a/triggers/venus-project-initiation.js
+++ b/triggers/venus-project-initiation.js
@@ -1,0 +1,93 @@
+const { getRandomElement } = require('../utils');
+const { enqueueMessage } = require('../outgoing-messages');
+
+// Patterns that might indicate someone is open to discussion or starting a conversation
+const conversationStartRegex = /^[^\p{L}]*(что[^\p{L}]+делаешь|чем[^\p{L}]+занимаешься|что[^\p{L}]+нового|расскажи[^\p{L}]+о[^\p{L}]+себе|о[^\p{L}]+чём[^\p{L}]+поговорим|во[^\p{L}]+что|ну[^\p{L}]+рассказывай|что[^\p{L}]+интересного|какие[^\p{L}]+планы|что[^\p{L}]+думаешь|какое[^\p{L}]+мнение|интересно)[^\p{L}]*$/ui;
+
+// Alternative patterns for different conversation openers
+const generalQuestionRegex = /^[^\p{L}]*(что[^\p{L}]+знаешь[^\p{L}]+о|слышал[^\p{L}]+ли|известно[^\p{L}]+ли[^\p{L}]+тебе|что[^\p{L}]+скажешь[^\p{L}]+о|как[^\p{L}]+относишься[^\p{L}]+к|мнение[^\p{L}]+о)[^\p{L}]*$/ui;
+
+const questions = [
+  "Слышал ли ты о Проекте Венера или Жака Фреско?",
+  "Знаешь что-нибудь о Проекте Венера?",
+  "А ты слышал о Жаке Фреско и его идеях?",
+  "Интересно, знаком ли ты с Проектом Венера?",
+  "Что думаешь о Проекте Венера Жака Фреско?",
+  "Слышал ли ты о ресурсо-ориентированной экономике?",
+];
+
+const trigger = {
+  name: "VenusProjectInitiationTrigger",
+  condition: (context) => {
+    if (!context?.request?.isFromUser) {
+      return false;
+    }
+
+    // Don't trigger on outgoing messages
+    if (context?.request?.isOutbox) {
+      return false;
+    }
+
+    // Check if we haven't triggered this for this user recently
+    const now = new Date();
+    const lastTriggered = context?.state?.triggers?.[trigger.name]?.lastTriggered;
+
+    // Only trigger once per day per user
+    if (lastTriggered) {
+      const daysSinceTriggered = (now - new Date(lastTriggered)) / (1000 * 60 * 60 * 24);
+      if (daysSinceTriggered < 1) {
+        return false;
+      }
+    }
+
+    // Check if the conversation history suggests this is a good time to introduce the topic
+    const history = context?.state?.history;
+
+    // Trigger conditions:
+    // 1. If it's early in the conversation (2-5 messages total)
+    // 2. If the user asks a general question or starts a topic
+    // 3. If there's a natural conversation flow
+
+    if (history && history.length >= 2 && history.length <= 5) {
+      const lastMessage = history[0]?.text || '';
+
+      // Check if the last message is asking what the bot does or general conversation
+      if (conversationStartRegex.test(lastMessage) || generalQuestionRegex.test(lastMessage)) {
+        return true;
+      }
+
+      // Also trigger on general conversational openings after greetings
+      const hasRecentGreeting = history.slice(0, 3).some(msg =>
+        msg?.text && /привет|здравствуй|добр|салют|ку|хай/ui.test(msg.text)
+      );
+
+      if (hasRecentGreeting && lastMessage.length > 10) {
+        return true;
+      }
+    }
+
+    return false;
+  },
+  action: async (context) => {
+    // Mark that we've triggered for this user
+    if (!context.state.triggers) {
+      context.state.triggers = {};
+    }
+    if (!context.state.triggers[trigger.name]) {
+      context.state.triggers[trigger.name] = {};
+    }
+    context.state.triggers[trigger.name].lastTriggered = new Date().toISOString();
+
+    enqueueMessage({
+      ...context,
+      response: {
+        message: getRandomElement(questions)
+      }
+    });
+  }
+};
+
+module.exports = {
+  trigger,
+  questions
+};


### PR DESCRIPTION
## Summary

• Implemented a new message trigger that introduces The Venus Project or Jacque Fresco as a conversation topic
• The trigger activates during natural conversation openings when users ask general questions or start discussions
• Includes smart timing to avoid spam and respects conversation flow

## Implementation Details

### New Files
- `triggers/venus-project-initiation.js` - Main trigger implementation with pattern matching for conversation starters
- `__tests__/triggers/venus-project-initiation.js` - Comprehensive test suite 
- `experiments/test-venus-project-trigger.js` - Manual testing script

### Modified Files
- `index.js` - Added the new trigger to the triggers array

### Features
- **Smart Pattern Matching**: Detects conversation starters like "что делаешь?", "чем занимаешься?", etc.
- **Conversation Flow Awareness**: Only triggers in early conversation (2-5 messages) after natural openings
- **Rate Limiting**: Prevents spam by only triggering once per day per user
- **Multiple Question Variants**: Randomly selects from 6 different ways to ask about The Venus Project

### Test Coverage
- ✅ All 10 unit tests passing
- ✅ Covers positive and negative scenarios
- ✅ Tests rate limiting and conversation flow logic
- ✅ Validates message content and trigger activation

## Test Plan

- [x] Unit tests for trigger conditions and actions
- [x] Manual testing with various conversation scenarios  
- [x] Integration testing with existing trigger system
- [x] Verification that existing functionality is unaffected

Fixes #92

🤖 Generated with [Claude Code](https://claude.ai/code)