### PR TITLE
Fix greeting trigger to only respond on first message in 24+ hours

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/konard/vk-bot/issues/88
+Your prepared branch: issue-88-eb893f71
+Your prepared working directory: /tmp/gh-issue-solver-1758565435563
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/konard/vk-bot/issues/88
-Your prepared branch: issue-88-eb893f71
-Your prepared working directory: /tmp/gh-issue-solver-1758565435563
-
-Proceed.

--- a/__tests__/triggers/greeting.js
+++ b/__tests__/triggers/greeting.js
@@ -1,12 +1,17 @@
 const { trigger: greetingTrigger, outgoingGreetingStickersIds } = require('../../triggers/greeting');
 const { enqueueMessage } = require('../../outgoing-messages');
+const { getOrLoadMessages } = require('../../messages-cache');
+const { DateTime } = require('luxon');
+
 jest.mock('../../outgoing-messages');
+jest.mock('../../messages-cache');
 
 const triggerDescription = 'greeting trigger';
 
 describe(triggerDescription, () => {
   beforeEach(() => {
     enqueueMessage.mockClear();
+    getOrLoadMessages.mockClear();
   });
 
   test.each([
@@ -32,11 +37,29 @@ describe(triggerDescription, () => {
     ['Привет Привет 🤝🤝🤝'],
     ['хай!'],
     ['Хэллоу'],
-  ])(`"%s" message matches ${triggerDescription} and gives expected response`, (incomingMessage) => {
-    const context = { request: { peerType: 'user', isFromUser: true, text: incomingMessage } };
-    expect(greetingTrigger.condition(context)).toBe(true);
-    if (greetingTrigger.condition(context)) {
-      greetingTrigger.action(context);
+  ])(`"%s" message matches ${triggerDescription} and gives expected response`, async (incomingMessage) => {
+    // Mock messages showing this is the first message in 24+ hours
+    const now = DateTime.now();
+    const oldMessage = {
+      id: 123,
+      date: now.minus({ hours: 25 }).toSeconds() // 25 hours ago
+    };
+    getOrLoadMessages.mockResolvedValue([oldMessage]);
+
+    const context = {
+      request: {
+        peerType: 'user',
+        isFromUser: true,
+        text: incomingMessage,
+        user_id: 456,
+        id: 789
+      },
+      state: { triggers: {} }
+    };
+
+    expect(await greetingTrigger.condition(context)).toBe(true);
+    if (await greetingTrigger.condition(context)) {
+      await greetingTrigger.action(context);
     }
     expect(enqueueMessage).toHaveBeenCalled();
     const callArg = enqueueMessage.mock.calls[0][0];
@@ -91,15 +114,104 @@ describe(triggerDescription, () => {
     [9469],  // ХАЙ
     [79394], // ДАРОВА
     [54474], // БОНЖУР!
-  ])(`"%s" sticker matches ${triggerDescription} and gives expected response`, (incomingStickerId) => {
-    const context = { request: { peerType: 'user', isFromUser: true, attachments: [{ id: incomingStickerId }] } };
-    expect(greetingTrigger.condition(context)).toBe(true);
-    if (greetingTrigger.condition(context)) {
-      greetingTrigger.action(context);
+  ])(`"%s" sticker matches ${triggerDescription} and gives expected response`, async (incomingStickerId) => {
+    // Mock messages showing this is the first message in 24+ hours
+    const now = DateTime.now();
+    const oldMessage = {
+      id: 123,
+      date: now.minus({ hours: 25 }).toSeconds() // 25 hours ago
+    };
+    getOrLoadMessages.mockResolvedValue([oldMessage]);
+
+    const context = {
+      request: {
+        peerType: 'user',
+        isFromUser: true,
+        attachments: [{ id: incomingStickerId }],
+        user_id: 456,
+        id: 789
+      },
+      state: { triggers: {} }
+    };
+
+    expect(await greetingTrigger.condition(context)).toBe(true);
+    if (await greetingTrigger.condition(context)) {
+      await greetingTrigger.action(context);
     }
     expect(enqueueMessage).toHaveBeenCalled();
     const callArg = enqueueMessage.mock.calls[0][0];
     expect(callArg).toEqual(expect.objectContaining(context));
     expect(outgoingGreetingStickersIds).toContain(callArg.response.sticker_id);
+  });
+
+  test('should NOT treat greeting text as greeting when last message was recent', async () => {
+    // Mock messages showing recent activity (less than 24 hours)
+    const now = DateTime.now();
+    const recentMessage = {
+      id: 123,
+      date: now.minus({ hours: 5 }).toSeconds() // 5 hours ago
+    };
+    getOrLoadMessages.mockResolvedValue([recentMessage]);
+
+    const context = {
+      request: {
+        peerType: 'user',
+        isFromUser: true,
+        text: 'Привет',
+        user_id: 456,
+        id: 789
+      },
+      state: { triggers: {} }
+    };
+
+    expect(await greetingTrigger.condition(context)).toBe(false);
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
+  test('should treat greeting text as greeting when it is first message ever', async () => {
+    // Mock empty message history
+    getOrLoadMessages.mockResolvedValue([]);
+
+    const context = {
+      request: {
+        peerType: 'user',
+        isFromUser: true,
+        text: 'Привет',
+        user_id: 456,
+        id: 789
+      },
+      state: { triggers: {} }
+    };
+
+    expect(await greetingTrigger.condition(context)).toBe(true);
+  });
+
+  test('should NOT trigger when already triggered within 24 hours', async () => {
+    // Mock old message history (25+ hours ago)
+    const now = DateTime.now();
+    const oldMessage = {
+      id: 123,
+      date: now.minus({ hours: 25 }).toSeconds()
+    };
+    getOrLoadMessages.mockResolvedValue([oldMessage]);
+
+    const context = {
+      request: {
+        peerType: 'user',
+        isFromUser: true,
+        text: 'Привет',
+        user_id: 456,
+        id: 789
+      },
+      state: {
+        triggers: {
+          GreetingTrigger: {
+            lastTriggered: now.minus({ hours: 12 }) // Triggered 12 hours ago
+          }
+        }
+      }
+    };
+
+    expect(await greetingTrigger.condition(context)).toBe(false);
   });
 });

--- a/triggers/greeting.js
+++ b/triggers/greeting.js
@@ -2,6 +2,7 @@ const { hasSticker, getRandomElement } = require('../utils');
 const { sendMessage } = require('../outgoing-messages');
 const { DateTime } = require('luxon');
 const { stickers } = require('../stickers');
+const { getOrLoadMessages } = require('../messages-cache');
 
 const greetingRegex = /^[^\p{L}]*((трям|🖖|👋|🖐|мо[иё] приветстви[ея]|салам|салют|з?д[ао]ров[ао]?|ку|q+|шалом|хай|хэллоу|йоу?|привет(ствую|ики?)?|здрав?с(твуй|ь)?(те)?|дд|((день|вечер)[^\p{L}]+)?добр(ый([^\p{L}]*(день|вечер))?|ое[^\p{L}]*утро|ой[^\p{L}]*ночи|ого[^\p{L}]*времени[^\p{L}]*суток))[^\p{L}]*)+([^\p{L}]*(тебе|вам))?[^\p{L}]*$/ui;
 
@@ -168,38 +169,51 @@ const outgoingGreetingStickersIds = [
 
 const trigger = {
   name: "GreetingTrigger",
-  condition: (context) => {
+  condition: async (context) => {
     if (context.request.peerType !== "user") {
       return false;
     }
 
-    // console.log('context!!', context)
-    // console.log('!context?.request?.isFromUser', !context?.request?.isFromUser)
-    // if (!context?.request?.isFromUser) {
-    //   return false;
-    // }
+    // Check if message matches greeting patterns first
+    const isGreetingPattern = greetingRegex.test(context.request.text) || hasSticker(context.request, incomingGreetingStickersIds);
+    if (!isGreetingPattern) {
+      return false;
+    }
+
     const now = DateTime.now();
-    // console.log('now', now);
     const lastTriggered = context?.state?.triggers?.[trigger.name]?.lastTriggered;
-    // console.log('lastTriggered', lastTriggered);
     const lastTriggeredDiff = lastTriggered ? now.diff(lastTriggered, 'days').days : Number.MAX_SAFE_INTEGER;
-    // console.log('lastTriggeredDiff >= 1', lastTriggeredDiff >= 1)
-    // console.log('greetingRegex.test(context.request.text)', greetingRegex.test(context.request.text))
-    // console.log('hasSticker(context.request, incomingGreetingStickersIds)', hasSticker(context.request, incomingGreetingStickersIds))
-    // console.log(`lastTriggeredDiff >= 1
-    // && (
-    //     greetingRegex.test(context.request.text)
-    // ||  hasSticker(context.request, incomingGreetingStickersIds)
-    // )`, lastTriggeredDiff >= 1
-    // && (
-    //     greetingRegex.test(context.request.text)
-    // ||  hasSticker(context.request, incomingGreetingStickersIds)
-    // ))
-    return lastTriggeredDiff >= 1
-        && (
-            greetingRegex.test(context.request.text)
-        ||  hasSticker(context.request, incomingGreetingStickersIds)
-        );
+
+    // If already triggered within 24 hours, don't trigger again
+    if (lastTriggeredDiff < 1) {
+      return false;
+    }
+
+    // Check if this is the first message in 24+ hours
+    try {
+      const messages = await getOrLoadMessages({ context, friendId: context.request.user_id });
+      if (!messages || messages.length === 0) {
+        // No message history, treat as first message
+        return true;
+      }
+
+      // Check if the last message (excluding current one) was sent more than 24 hours ago
+      const lastMessage = messages.find(msg => msg.id !== context.request.id);
+      if (!lastMessage) {
+        // Only one message (current), treat as first message
+        return true;
+      }
+
+      const lastMessageTime = DateTime.fromSeconds(lastMessage.date);
+      const timeSinceLastMessage = now.diff(lastMessageTime, 'hours').hours;
+
+      // Only treat as greeting if it's the first message in 24+ hours
+      return timeSinceLastMessage >= 24;
+    } catch (error) {
+      console.error('Error checking message history for greeting trigger:', error);
+      // If we can't check message history, fall back to previous behavior
+      return true;
+    }
   },
   action: async (context) => {
     if (context?.request?.isOutbox) {


### PR DESCRIPTION
## Summary
Fixes issue #88 where the bot was incorrectly treating any message matching greeting patterns as a greeting, regardless of conversation context.

### Changes Made
- **Enhanced greeting trigger logic**: Modified the condition to check if this is the first message in 24+ hours before treating as greeting
- **Added message history validation**: Uses `getOrLoadMessages` to check conversation timeline
- **Maintained existing cooldown**: Preserves the 24-hour trigger cooldown mechanism
- **Updated tests**: Modified test suite to handle async condition function and added new test cases

### Implementation Details
The greeting trigger now follows this logic:
1. Check if message matches greeting patterns (text regex or greeting stickers)
2. Verify that the trigger hasn't been fired in the last 24 hours
3. **NEW**: Check message history to ensure this is the first message in 24+ hours
4. Only then treat the message as a greeting and respond

This prevents scenarios where users send greeting-like messages in ongoing conversations from being treated as actual greetings.

### Test Cases Added
- ✅ Should NOT treat greeting text as greeting when last message was recent (< 24 hours)
- ✅ Should treat greeting text as greeting when it's the first message ever  
- ✅ Should NOT trigger when already triggered within 24 hours

## Test plan
- [x] Run existing greeting trigger tests to ensure compatibility
- [x] Test with recent conversation history (should not trigger)
- [x] Test with old conversation history (should trigger)
- [x] Test with empty conversation history (should trigger)
- [x] Test cooldown mechanism still works

🤖 Generated with [Claude Code](https://claude.ai/code)