### PR TITLE
Add initiation topic trigger: 'Do you have a dream?'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/konard/vk-bot/issues/87
-Your prepared branch: issue-87-e6099423
-Your prepared working directory: /tmp/gh-issue-solver-1758565689029
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/konard/vk-bot/issues/87
+Your prepared branch: issue-87-e6099423
+Your prepared working directory: /tmp/gh-issue-solver-1758565689029
+
+Proceed.

--- a/__tests__/triggers/initiation-topic.js
+++ b/__tests__/triggers/initiation-topic.js
@@ -1,0 +1,182 @@
+const { trigger: initiationTopicTrigger, initiationTopicQuestions } = require('../../triggers/initiation-topic');
+const { enqueueMessage } = require('../../outgoing-messages');
+const { DateTime } = require('luxon');
+
+jest.mock('../../outgoing-messages');
+
+const triggerDescription = 'initiation topic trigger';
+
+describe(triggerDescription, () => {
+  beforeEach(() => {
+    enqueueMessage.mockClear();
+    // Reset Math.random mock
+    jest.spyOn(Math, 'random').mockRestore();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('should not trigger for group conversations', () => {
+    const context = {
+      request: {
+        peerType: "chat",
+        isOutbox: false
+      },
+      state: { history: Array(10).fill({ date: DateTime.now().toSeconds() }) }
+    };
+    expect(initiationTopicTrigger.condition(context)).toBe(false);
+  });
+
+  test('should not trigger for outgoing messages', () => {
+    const context = {
+      request: {
+        peerType: "user",
+        isOutbox: true
+      },
+      state: { history: Array(10).fill({ date: DateTime.now().toSeconds() }) }
+    };
+    expect(initiationTopicTrigger.condition(context)).toBe(false);
+  });
+
+  test('should not trigger if recently triggered (less than 7 days)', () => {
+    const context = {
+      request: {
+        peerType: "user",
+        isOutbox: false
+      },
+      state: {
+        history: Array(10).fill({ date: DateTime.now().toSeconds() }),
+        triggers: {
+          'InitiationTopicTrigger': {
+            lastTriggered: DateTime.now().minus({ days: 3 })
+          }
+        }
+      }
+    };
+    expect(initiationTopicTrigger.condition(context)).toBe(false);
+  });
+
+  test('should not trigger with insufficient conversation history (less than 5 messages)', () => {
+    const context = {
+      request: {
+        peerType: "user",
+        isOutbox: false
+      },
+      state: {
+        history: Array(3).fill({ date: DateTime.now().toSeconds() })
+      }
+    };
+    expect(initiationTopicTrigger.condition(context)).toBe(false);
+  });
+
+  test('should not trigger with insufficient recent activity (less than 2 recent messages)', () => {
+    const oldMessages = Array(10).fill({
+      date: DateTime.now().minus({ days: 10 }).toSeconds(),
+      text: 'old message'
+    });
+    const context = {
+      request: {
+        peerType: "user",
+        isOutbox: false
+      },
+      state: {
+        history: oldMessages
+      }
+    };
+    expect(initiationTopicTrigger.condition(context)).toBe(false);
+  });
+
+  test('should not trigger with too much recent activity (more than 10 recent messages)', () => {
+    const recentMessages = Array(15).fill({
+      date: DateTime.now().minus({ days: 1 }).toSeconds(),
+      text: 'recent message'
+    });
+    const context = {
+      request: {
+        peerType: "user",
+        isOutbox: false
+      },
+      state: {
+        history: recentMessages
+      }
+    };
+    expect(initiationTopicTrigger.condition(context)).toBe(false);
+  });
+
+  test('should not trigger if dream-related topics were recently discussed', () => {
+    const recentMessages = Array(5).fill({
+      date: DateTime.now().minus({ days: 1 }).toSeconds(),
+      text: 'we talked about dreams yesterday'
+    });
+    const context = {
+      request: {
+        peerType: "user",
+        isOutbox: false
+      },
+      state: {
+        history: recentMessages
+      }
+    };
+    expect(initiationTopicTrigger.condition(context)).toBe(false);
+  });
+
+  test('should trigger when all conditions are met and random chance succeeds', () => {
+    // Mock Math.random to return 0.2 (less than 0.3 threshold)
+    jest.spyOn(Math, 'random').mockReturnValue(0.2);
+
+    const recentMessages = Array(5).fill({
+      date: DateTime.now().minus({ days: 1 }).toSeconds(),
+      text: 'normal conversation'
+    });
+    const context = {
+      request: {
+        peerType: "user",
+        isOutbox: false
+      },
+      state: {
+        history: recentMessages
+      }
+    };
+    expect(initiationTopicTrigger.condition(context)).toBe(true);
+  });
+
+  test('should not trigger when random chance fails', () => {
+    // Mock Math.random to return 0.5 (greater than 0.3 threshold)
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+    const recentMessages = Array(5).fill({
+      date: DateTime.now().minus({ days: 1 }).toSeconds(),
+      text: 'normal conversation'
+    });
+    const context = {
+      request: {
+        peerType: "user",
+        isOutbox: false
+      },
+      state: {
+        history: recentMessages
+      }
+    };
+    expect(initiationTopicTrigger.condition(context)).toBe(false);
+  });
+
+  test('should enqueue message with correct content when triggered', async () => {
+    const context = {
+      request: {
+        peerType: "user",
+        isOutbox: false
+      },
+      vk: {},
+      response: {}
+    };
+
+    await initiationTopicTrigger.action(context);
+
+    expect(enqueueMessage).toHaveBeenCalled();
+    const callArg = enqueueMessage.mock.calls[0][0];
+    expect(callArg.request).toEqual(context.request);
+    expect(callArg.vk).toEqual(context.vk);
+    expect(initiationTopicQuestions).toContain(callArg.response.message);
+  });
+});

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ const triggers = [
   // require('./triggers/who-multiple').trigger,
   // require('./triggers/who-singular').trigger,
   // require('./triggers/have-we-talked-before').trigger,
-  // require('./triggers/engage-with-acquaintance').trigger
+  // require('./triggers/engage-with-acquaintance').trigger,
+  require('./triggers/initiation-topic').trigger
 ];
 
 const token = getToken();

--- a/triggers/initiation-topic.js
+++ b/triggers/initiation-topic.js
@@ -1,0 +1,85 @@
+const { getRandomElement } = require('../utils');
+const { enqueueMessage } = require('../outgoing-messages');
+const { DateTime } = require('luxon');
+
+const initiationTopicQuestions = [
+  "Do you have a dream?",
+  "У тебя есть мечта?",
+];
+
+const trigger = {
+  name: "InitiationTopicTrigger",
+  condition: (context) => {
+    // Only trigger for user conversations, not groups
+    if (context.request.peerType !== "user") {
+      return false;
+    }
+
+    // Don't trigger on outgoing messages
+    if (context?.request?.isOutbox) {
+      return false;
+    }
+
+    const now = DateTime.now();
+    const lastTriggered = context?.state?.triggers?.[trigger.name]?.lastTriggered;
+
+    // Calculate how many days since this trigger was last executed for this peer
+    const lastTriggeredDiff = lastTriggered ? now.diff(lastTriggered, 'days').days : Number.MAX_SAFE_INTEGER;
+
+    // Only trigger once per week (7 days) per user to avoid being too pushy
+    if (lastTriggeredDiff < 7) {
+      return false;
+    }
+
+    // Check if we have enough conversation history to determine if this is appropriate
+    const history = context?.state?.history || [];
+
+    // Only trigger if we have had some previous conversation (at least 5 messages exchanged)
+    if (history.length < 5) {
+      return false;
+    }
+
+    // Count recent messages (last 3 days) to see if conversation is active
+    const threeDaysAgo = now.minus({ days: 3 });
+    const recentMessages = history.filter(msg => {
+      const msgDate = DateTime.fromSeconds(msg.date);
+      return msgDate > threeDaysAgo;
+    });
+
+    // Only trigger if there has been some recent activity (at least 2 messages in last 3 days)
+    // but not too much (less than 10 messages to avoid interrupting active conversation)
+    const recentMessageCount = recentMessages.length;
+    if (recentMessageCount < 2 || recentMessageCount > 10) {
+      return false;
+    }
+
+    // Check if we recently asked about dreams or similar topics
+    const dreamRelatedKeywords = ['мечта', 'dream', 'цель', 'goal', 'желание', 'wish', 'хочу', 'want'];
+    const recentText = recentMessages
+      .map(msg => msg.text || '')
+      .join(' ')
+      .toLowerCase();
+
+    const hasDreamTopic = dreamRelatedKeywords.some(keyword => recentText.includes(keyword));
+    if (hasDreamTopic) {
+      return false;
+    }
+
+    // Random chance to trigger (30% chance when all conditions are met)
+    // This prevents the bot from being too predictable
+    return Math.random() < 0.3;
+  },
+  action: async (context) => {
+    return enqueueMessage({
+      ...context,
+      response: {
+        message: getRandomElement(initiationTopicQuestions)
+      }
+    });
+  }
+};
+
+module.exports = {
+  trigger,
+  initiationTopicQuestions
+};


### PR DESCRIPTION
## Summary
- Implements a proactive conversation starter trigger that asks "Do you have a dream?" to initiate meaningful conversations
- The trigger is intelligent and only activates under appropriate conditions to avoid being intrusive
- Supports both English and Russian versions of the question

## Features
- **Smart timing**: Only triggers once per week per user (7-day cooldown)
- **Context awareness**: Requires conversation history and monitors recent activity levels
- **Topic avoidance**: Skips triggering if dream-related topics were recently discussed
- **Predictability reduction**: Uses 30% random chance when conditions are met
- **User-only conversations**: Only works in direct messages, not group chats

## Implementation Details
- Created `triggers/initiation-topic.js` with the main trigger logic
- Added comprehensive tests in `__tests__/triggers/initiation-topic.js` (10 test cases, all passing)
- Integrated the trigger into the main `index.js` triggers array
- Follows existing codebase patterns and conventions

## Test Coverage
The implementation includes thorough testing for:
- Group conversation filtering
- Outgoing message filtering
- Recent trigger cooldown logic
- Conversation history requirements
- Activity level monitoring
- Dream topic detection
- Random chance behavior
- Message enqueueing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)