### PR TITLE
Fix AbortError timeout issue by increasing VK API timeout configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/konard/vk-bot/issues/84
+Your prepared branch: issue-84-39bf0e82
+Your prepared working directory: /tmp/gh-issue-solver-1758566037325
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/konard/vk-bot/issues/84
-Your prepared branch: issue-84-39bf0e82
-Your prepared working directory: /tmp/gh-issue-solver-1758566037325
-
-Proceed.

--- a/experiments/test-timeout-fix.js
+++ b/experiments/test-timeout-fix.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+const { getToken, createVK } = require('../utils');
+
+async function testTimeoutConfiguration() {
+  console.log('Testing VK API timeout configuration fix for AbortError issue...');
+
+  try {
+    const token = getToken();
+    const vk = createVK(token);
+
+    console.log('VK instance created successfully with increased timeout (30s) and retry limit (5)');
+
+    // Test a simple API call to verify the configuration works
+    console.log('Testing a simple API call...');
+    const response = await vk.api.account.getInfo();
+
+    console.log('API call successful!');
+    console.log('Country:', response.country);
+    console.log('Lang:', response.lang);
+
+    console.log('\n✅ Timeout configuration test passed!');
+    console.log('The AbortError issue should be resolved with:');
+    console.log('- apiTimeout: 30000ms (30 seconds)');
+    console.log('- apiRetryLimit: 5 attempts');
+
+  } catch (error) {
+    console.error('❌ Test failed:', error.message);
+
+    if (error.name === 'AbortError') {
+      console.error('AbortError still occurring - may need further timeout adjustments');
+    } else if (error.code === 5) {
+      console.error('Invalid token - please check your token file');
+    } else {
+      console.error('Other error occurred:', error);
+    }
+
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  testTimeoutConfiguration();
+}
+
+module.exports = { testTimeoutConfiguration };

--- a/friends.js
+++ b/friends.js
@@ -1,7 +1,6 @@
-const { VK } = require('vk-io');
-const { sleep, getToken, second, ms } = require('./utils');
+const { sleep, getToken, createVK, second, ms } = require('./utils');
 const token = getToken();
-const vk = new VK({ token });
+const vk = createVK(token);
 
 const targetFriendsCount = Number(process.argv[2]) || 0;
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const { second, minute, ms } = require('./time-units');
-const { executeTrigger, getToken } = require('./utils');
+const { executeTrigger, getToken, createVK } = require('./utils');
 const { handleOutgoingMessage } = require('./outgoing-messages');
 
 const peers = {}; // TODO: keep state about what triggers then last triggered for each peer
@@ -19,8 +19,7 @@ const triggers = [
 ];
 
 const token = getToken();
-const { VK } = require('vk-io');
-const vk = new VK({ token });
+const vk = createVK(token);
 
 vk.updates.on(['message_new'], async (request) => {
   let peerState;

--- a/load-messages.js
+++ b/load-messages.js
@@ -1,10 +1,9 @@
 const fs = require('fs');
 const path = require('path');
-const { VK } = require('vk-io');
-const { getToken, sleep, minute, ms } = require('./utils');
+const { getToken, createVK, sleep, minute, ms } = require('./utils');
 
 const token = getToken();
-const vk = new VK({ token });
+const vk = createVK(token);
 
 async function loadMessages(friendId) {
   try {

--- a/triggers/send-birthday-congratulations.js
+++ b/triggers/send-birthday-congratulations.js
@@ -1,8 +1,7 @@
-const { VK } = require('vk-io');
-const { getRandomElement, sleep, getToken, minute, ms } = require('../utils');
+const { getRandomElement, sleep, getToken, createVK, minute, ms } = require('../utils');
 const { enqueueMessage } = require('../outgoing-messages');
 const token = getToken();
-const vk = new VK({ token });
+const vk = createVK(token);
 
 const birthdayStickerIds = [
   60302,

--- a/utils.js
+++ b/utils.js
@@ -178,8 +178,18 @@ async function executeTrigger(trigger, context) {
   }
 }
 
+function createVK(token) {
+  const { VK } = require('vk-io');
+  return new VK({
+    token,
+    apiTimeout: 30000, // Increase timeout to 30 seconds to prevent AbortError
+    apiRetryLimit: 5   // Increase retry attempts for better reliability
+  });
+}
+
 module.exports = {
   getToken,
+  createVK,
   getRandomElement,
   hasSticker,
   sleep,


### PR DESCRIPTION
'## Summary
• Fixed AbortError timeout issue by implementing centralized VK API configuration with increased timeout values
• Created createVK utility function to standardize VK instance creation across the codebase  
• Increased apiTimeout from default 10s to 30s to prevent node-fetch AbortErrors
• Enhanced reliability with increased apiRetryLimit from 3 to 5 attempts

## Test plan
- [x] Added test script to verify timeout configuration works correctly
- [x] Updated main bot (index.js) and critical modules to use new centralized configuration
- [x] Verified changes maintain backward compatibility with existing functionality
- [ ] Run the bot in production to confirm AbortError issue is resolved
- [ ] Monitor API call success rates after deployment

### Files Modified
- : Added createVK function with timeout configuration
- : Updated to use centralized VK configuration  
- : Applied timeout fix for message loading operations
- : Updated friend management operations with new timeout
- : Fixed birthday trigger timeout
- : Added test script for verification

### Technical Details
The issue was caused by vk-io'\''s default apiTimeout of 10 seconds being too aggressive for certain VK API operations, particularly:
- Loading message history (index.js:35)
- Friend requests and user lookups
- Large data operations that exceed network timeout

The fix centralizes VK instance creation with:


🤖 Generated with [Claude Code](https://claude.ai/code)


Fixes #84'