### PR TITLE
Add 'what do you do' trigger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/konard/vk-bot/issues/74
+Your prepared branch: issue-74-3613be8c
+Your prepared working directory: /tmp/gh-issue-solver-1758566900411
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/konard/vk-bot/issues/74
-Your prepared branch: issue-74-3613be8c
-Your prepared working directory: /tmp/gh-issue-solver-1758566900411
-
-Proceed.

--- a/__tests__/triggers/what-do-you-do.js
+++ b/__tests__/triggers/what-do-you-do.js
@@ -1,0 +1,52 @@
+const { trigger: whatDoYouDoTrigger, answers: whatDoYouDoAnswers } = require('../../triggers/what-do-you-do');
+const { enqueueMessage } = require('../../outgoing-messages');
+jest.mock('../../outgoing-messages');
+
+const triggerDescription = 'what do you do trigger';
+
+describe(triggerDescription, () => {
+  beforeEach(() => {
+    enqueueMessage.mockClear();
+  });
+
+  test.each([
+    ['Что делаешь'],
+    ['Что делаешь?'],
+    ['Чем занимаешься?'],
+    ['Чем занят?'],
+    ['Чем занят'],
+    ['что делаешь'],
+    ['чем занимаешься'],
+    ['чем занят'],
+    ['Что делаешь сейчас?'],
+    ['😊 что делаешь?'],
+  ])(`"%s" matches ${triggerDescription} and gives expected response`, (incomingMessage) => {
+    const context = { request: { isFromUser: true, isOutbox: false, text: incomingMessage } };
+    expect(whatDoYouDoTrigger.condition(context)).toBe(true);
+    if (whatDoYouDoTrigger.condition(context)) {
+      whatDoYouDoTrigger.action(context);
+    }
+    expect(enqueueMessage).toHaveBeenCalled();
+    const callArg = enqueueMessage.mock.calls[0][0];
+    expect(callArg).toEqual(expect.objectContaining(context));
+    expect(whatDoYouDoAnswers).toContain(callArg.response.message);
+  });
+
+  test.each([
+    ['Как дела?'],
+    ['Что такое программирование?'],
+    ['Кто ты?'],
+    ['Привет'],
+    ['Как жизнь?'],
+    ['Что нового?'],
+    ['Что за дела?'],
+    ['А чем занимаешься?']
+  ])(`"%s" does not match ${triggerDescription}`, (incomingMessage) => {
+    const context = { request: { isOutbox: false, text: incomingMessage } };
+    expect(whatDoYouDoTrigger.condition(context)).toBe(false);
+    if (whatDoYouDoTrigger.condition(context)) {
+      whatDoYouDoTrigger.action(context);
+    }
+    expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+});

--- a/triggers/what-do-you-do.js
+++ b/triggers/what-do-you-do.js
@@ -1,0 +1,41 @@
+const { getRandomElement } = require('../utils');
+const { enqueueMessage } = require('../outgoing-messages');
+
+const whatDoYouDoRegex = /^[^\p{L}\?]*(что[^\p{L}]*делаешь|чем[^\p{L}]*(занимаешься|занят))/ui;
+
+const answers = [
+  "Программирую.",
+  "Программированием занимаюсь.",
+  "Автоматизирую.",
+  "Автоматизацией занимаюсь.",
+  "Кодом занимаюсь.",
+  "Разработкой занимаюсь.",
+  "Работаю над кодом.",
+  "Пишу код.",
+  "Разрабатываю программы.",
+  "Занимаюсь разработкой."
+];
+
+const trigger = {
+  name: "WhatDoYouDoTrigger",
+  condition: (context) => {
+    if (!context?.request?.isFromUser) {
+      return false;
+    }
+    return !context?.request?.isOutbox
+        && whatDoYouDoRegex.test(context.request.text);
+  },
+  action: (context) => {
+    enqueueMessage({
+      ...context,
+      response: {
+        message: getRandomElement(answers)
+      }
+    });
+  }
+};
+
+module.exports = {
+  trigger,
+  answers
+};


### PR DESCRIPTION
## Summary
- Implements trigger for "what do you do" type questions as requested in issue #74
- Handles Russian phrases: "Что делаешь", "Чем занимаешься?", "Чем занят?"
- Responds with random programming-related activities

## Implementation Details
- **File**: `triggers/what-do-you-do.js`
- **Regex pattern**: Matches variations of "что делаешь" and "чем занимаешься/занят"
- **Responses**: 10 different programming-related answers
- **Test coverage**: 18 test cases covering positive and negative matches

## Test Results
- ✅ All new trigger tests pass (18/18)
- ✅ Existing working triggers remain functional
- ⚠️ Some pre-existing test failures in other triggers (not related to this change)

## Files Changed
- `triggers/what-do-you-do.js` - New trigger implementation
- `__tests__/triggers/what-do-you-do.js` - Comprehensive test suite

Fixes #74

🤖 Generated with [Claude Code](https://claude.ai/code)