### PR TITLE
Fix APIError Code №10 handling in post deletion loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/konard/vk-bot/issues/111
-Your prepared branch: issue-111-fbc7cc11
-Your prepared working directory: /tmp/gh-issue-solver-1758594610709
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/konard/vk-bot/issues/111
+Your prepared branch: issue-111-fbc7cc11
+Your prepared working directory: /tmp/gh-issue-solver-1758594610709
+
+Proceed.

--- a/triggers/send-invitation-posts-for-friends.js
+++ b/triggers/send-invitation-posts-for-friends.js
@@ -163,6 +163,11 @@ async function sendInvitationPosts(context) {
               console.warn(trigger.name, `Post ${post.id} is not found. It may already be deleted.`);
               continue;
             }
+            if (e.code === 10) { // APIError: Code №10 - Internal server error: Unknown error, try later
+              console.warn(trigger.name, `Warning: Unknown error occurred while deleting post ${post.id}.
+As we explicitly asked to try later by VK API, skipping this post deletion and continuing.`);
+              continue;
+            }
             throw e;
           }
         }


### PR DESCRIPTION
## Summary
- Fixed missing error code 10 handling in the post deletion loop of `SendInvitationPostsForFriends` trigger
- Added proper error handling for `APIError: Code №10 - Internal server error: Unknown error, try later` during post deletion operations

## Problem
The issue occurred when VK API returned error code 10 (Internal server error) during the post deletion process. The inner try-catch block in the post deletion loop (lines 157-167) was missing handling for this specific error code, causing the entire process to fail instead of gracefully continuing.

## Solution
Added error code 10 handling in the post deletion loop that:
- Logs a warning message when the error occurs
- Skips the problematic post deletion and continues with the next post
- Maintains consistency with the existing error handling pattern in the outer try-catch block

## Changes
- `triggers/send-invitation-posts-for-friends.js:166-170` - Added error code 10 handling with appropriate warning message

## Test plan
- [x] Verified JavaScript syntax is valid using `node -c`
- [x] Confirmed the fix follows the same error handling pattern used elsewhere in the codebase
- [x] The solution maintains the existing behavior while preventing crashes

Fixes #111

🤖 Generated with [Claude Code](https://claude.ai/code)