### PR TITLE
Add support for English well-being inquiries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-13-16796c52
-Your prepared working directory: /tmp/gh-issue-solver-1760719246597
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-13-16796c52
+Your prepared working directory: /tmp/gh-issue-solver-1760719246597
+
+Proceed.

--- a/__tests__/triggers/well-being.js
+++ b/__tests__/triggers/well-being.js
@@ -17,6 +17,16 @@ describe(triggerDescription, () => {
     ['Привет как дела😏😏'],
     ['How are you'],
     ['How are you?'],
+    ['How are you doing?'],
+    ['How have you been?'],
+    ['How\'s everything?'],
+    ['How\'s it going?'],
+    ['How are things going?'],
+    ['What\'s going on?'],
+    ['What\'s new?'],
+    ['What\'s up?'],
+    ['Whassup?'],
+    ['What are you up to?'],
   ])(`"%s" matches ${triggerDescription} and gives expected response`, (incomingMessage) => {
     const context = { request: { isFromUser: true, isOutbox: false, text: incomingMessage } };
     expect(wellBeingTrigger.condition(context)).toBe(true);

--- a/experiments/test-well-being-regex.js
+++ b/experiments/test-well-being-regex.js
@@ -1,0 +1,39 @@
+// Test complete regex pattern
+const wellBeingQuestionRegex = /(как)[^\p{L}]+(поживаешь|дела|жизнь)|^[^\p{L}\?]*(how|what)\b[^\p{L}]+(are|is|have|'?s)\b[^\p{L}]+(you|everything|it|things|going|new|up|been)\b.*$|^.*\b(whassup)\b.*$/ui;
+
+const shouldMatch = [
+  'Привет как дела😏😏',
+  'Whassup?',
+  'What\'s up?',
+  'How are you?',
+  'Как дела?',
+  'Как жизнь?',
+  'Как поживаешь?',
+  'Как дела',
+  'How are you',
+  'How are you doing?',
+  'How have you been?',
+  'How\'s everything?',
+  'How\'s it going?',
+  'How are things going?',
+  'What\'s going on?',
+  'What\'s new?',
+  'What are you up to?'
+];
+
+const shouldNotMatch = [
+  'Чем занимаешься?',
+  'Какая цель добавления в друзья?'
+];
+
+console.log('Testing shouldMatch:');
+shouldMatch.forEach(test => {
+  const matches = wellBeingQuestionRegex.test(test);
+  console.log(`"${test}" matches: ${matches} ${matches ? '✓' : '✗ FAIL'}`);
+});
+
+console.log('\nTesting shouldNotMatch:');
+shouldNotMatch.forEach(test => {
+  const matches = wellBeingQuestionRegex.test(test);
+  console.log(`"${test}" matches: ${matches} ${!matches ? '✓' : '✗ FAIL'}`);
+});

--- a/triggers/well-being.js
+++ b/triggers/well-being.js
@@ -1,7 +1,11 @@
 const { getRandomElement } = require('../utils');
 const { enqueueMessage } = require('../outgoing-messages');
 
-const wellBeingQuestionRegex = /^[^\p{L}\?]*(как)[^\p{L}\?]*(поживаешь|дела|жизнь)[^\p{L}\?]*\?+[^\p{L}]*$/ui;
+// Matches Russian phrases: "Как дела?", "Как жизнь?", "Как поживаешь?"
+// Matches English phrases: "How are you?", "How are you doing?", "How have you been?",
+// "How's everything?", "How's it going?", "How are things going?", "What's going on?",
+// "What's new?", "What's up?", "Whassup?", "What are you up to?"
+const wellBeingQuestionRegex = /(как)[^\p{L}]+(поживаешь|дела|жизнь)|^[^\p{L}\?]*(how|what)\b[^\p{L}]+(are|is|have|'?s)\b[^\p{L}]+(you|everything|it|things|going|new|up|been)\b.*$|^.*\b(whassup)\b.*$/ui;
 
 const answers = [
   "Хорошо, программирую.",


### PR DESCRIPTION
## Summary
This PR extends the `WellBeingTrigger` to recognize and respond to common English well-being inquiries, in addition to existing Russian phrases.

### Changes Made
- Updated the regex pattern in `triggers/well-being.js` to match all English phrases from issue #13:
  - "How are you?"
  - "How are you doing?"
  - "How have you been?"
  - "How's everything?"
  - "How's it going?"
  - "How are things going?"
  - "What's going on?"
  - "What's new?"
  - "What's up?"
  - "Whassup?"
  - "What are you up to?"

- Added comprehensive test coverage in `__tests__/triggers/well-being.js` for all supported phrases
- Created experiment script to validate regex patterns

### Test Results
All 19 tests pass ✓
- 17 tests verify that well-being phrases are correctly matched
- 2 tests verify that non-well-being phrases are correctly rejected

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)