### PR TITLE
Add error handling for VK API error code 5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-28-891027c0
+Your prepared working directory: /tmp/gh-issue-solver-1760721830836
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-28-891027c0
-Your prepared working directory: /tmp/gh-issue-solver-1760721830836
-
-Proceed.

--- a/triggers/delete-outgoing-requests.js
+++ b/triggers/delete-outgoing-requests.js
@@ -6,7 +6,16 @@ async function deleteOutgoingFriendRequests(context) {
     if (count <= 0) {
       return;
     }
-    const requests = await context.vk.api.friends.getRequests({ count, out: 1, need_viewed: 1 });
+    let requests;
+    try {
+      requests = await context.vk.api.friends.getRequests({ count, out: 1, need_viewed: 1 });
+    } catch (error) {
+      if (error.code === 5) { // APIError: Code №5 - User authorization failed: user is blocked
+        console.error('Could not get outgoing friend requests: User authorization failed. The account may be blocked or the access token is invalid.');
+        return;
+      }
+      throw error; // Re-throw other errors to be caught by outer try-catch
+    }
     if (requests.items.length <= 0) {
       console.log('No outgoing friend requests to be deleted');
       return requests;


### PR DESCRIPTION
## Summary

This PR adds proper error handling for VK API error code 5 (User authorization failed) in the delete-outgoing-requests trigger.

## Problem

Issue #28 reported an unhandled error when running `delete-outgoing-requests.js`:
```
APIError: Code №5 - User authorization failed: user is blocked.
```

The error occurred when calling `friends.getRequests` API method, causing the script to crash instead of gracefully handling the authorization failure.

## Solution

Added a try-catch block specifically for the `friends.getRequests` API call to:
- Catch VK API error code 5 (User authorization failed)
- Log a descriptive error message explaining the issue
- Gracefully exit instead of crashing

This follows the error handling pattern used in the `accept-friend-requests` trigger for handling similar VK API errors.

## Changes

- Modified `triggers/delete-outgoing-requests.js` to add error code 5 handling
- When error code 5 is detected, logs: "Could not get outgoing friend requests: User authorization failed. The account may be blocked or the access token is invalid."
- Other errors are re-thrown to be caught by the outer try-catch block

## Testing

- Reviewed existing error handling patterns in `accept-friend-requests` trigger
- Ran `npm test` to ensure no regressions (existing test failures are unrelated to this change)
- Verified the change follows the repository's error handling conventions

Fixes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)