### PR TITLE
Fix AbortError timeout in delete-outgoing-requests.js

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-30-f657504d
+Your prepared working directory: /tmp/gh-issue-solver-1760722217665
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-30-f657504d
-Your prepared working directory: /tmp/gh-issue-solver-1760722217665
-
-Proceed.

--- a/delete-outgoing-requests.js
+++ b/delete-outgoing-requests.js
@@ -2,7 +2,7 @@ const { trigger } = require('./triggers/delete-outgoing-requests');
 const { executeTrigger, getToken } = require('./utils');
 const { VK } = require('vk-io');
 const token = getToken();
-const vk = new VK({ token });
+const vk = new VK({ token, apiTimeout: 60000 }); // Increase timeout to 60 seconds
 
 const maxDeletedFriendsOutgoingRequestsCount = Number(process.argv[2]) || 0;
 


### PR DESCRIPTION
## Summary
Fixed the `AbortError: The operation was aborted` timeout issue in `delete-outgoing-requests.js` by increasing the VK API timeout configuration.

## Problem
When running `node delete-requests.js 250`, the script would fail with an `AbortError` because the default API timeout (10 seconds) was insufficient for operations involving many API calls to delete friend requests.

## Solution
Increased the `apiTimeout` parameter from the default 10 seconds to 60 seconds when initializing the VK instance in `delete-outgoing-requests.js:5`.

## Changes
- Modified `delete-outgoing-requests.js` to include `apiTimeout: 60000` (60 seconds) in the VK constructor options

## Technical Details
- The vk-io library uses a default `apiTimeout` of 10000ms (10 seconds)
- When processing large batches of friend requests, the cumulative time for API calls can exceed this limit
- The new 60-second timeout provides sufficient buffer for batch operations while still preventing indefinite hangs

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)