### PR TITLE
Fix AbortError in friends.get by increasing apiTimeout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-31-ef2fd5a6
+Your prepared working directory: /tmp/gh-issue-solver-1760722349649
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-31-ef2fd5a6
-Your prepared working directory: /tmp/gh-issue-solver-1760722349649
-
-Proceed.

--- a/index.js
+++ b/index.js
@@ -20,7 +20,10 @@ const triggers = [
 
 const token = getToken();
 const { VK } = require('vk-io');
-const vk = new VK({ token });
+const vk = new VK({
+  token,
+  apiTimeout: 30000 // Increase timeout to 30 seconds to handle slow friends.get requests
+});
 
 vk.updates.on(['message_new'], async (request) => {
   let peerState;


### PR DESCRIPTION
## Summary
Fixed the AbortError that occurred when retrieving friends to delete deactivated ones by increasing the VK API timeout configuration.

## Root Cause
The `vk.api.friends.get()` API call was timing out with the default 10-second timeout when attempting to retrieve large friend lists. This caused the following error:

```
AbortError: The operation was aborted.
    at abort (file:///root/bots/vk-bot/node_modules/node-fetch/src/index.js:70:18)
    at AbortSignal.abortAndFinalize (file:///root/bots/vk-bot/node_modules/node-fetch/src/index.js:89:4)
    at Timeout.<anonymous> (/root/bots/vk-bot/node_modules/vk-io/lib/index.js:1769:53)
```

## Solution
Increased the `apiTimeout` configuration from the default 10,000ms (10 seconds) to 30,000ms (30 seconds) when initializing the VK instance in `index.js`. This allows sufficient time for the VK API to respond when retrieving large friend lists.

## Changes
- Modified `index.js` to configure VK instance with `apiTimeout: 30000`

## Testing
The fix addresses the timeout issue by providing adequate time for the API request to complete. The 30-second timeout is a reasonable balance between allowing slow requests to complete and preventing indefinite hangs.

Fixes #31

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)